### PR TITLE
Fix for generating minified dists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn.lock
 lib
 .changelog/
 package-lock.json
+dist
 
 examples/**/build/js/*.js
 examples/**/build/js/*.map

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.0.1",
     "frint": "^5.2.1",
+    "frint-config": "^5.2.1",
     "frint-store": "^5.2.1",
     "istanbul": "^1.1.0-alpha.1",
     "istanbul-combine": "^0.3.0",

--- a/packages/frint-props/webpack.config.js
+++ b/packages/frint-props/webpack.config.js
@@ -31,7 +31,6 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /(node_modules)/,
         loader: 'babel-loader',
         query: {
           presets: [


### PR DESCRIPTION
## What's done

Fixed `npm run dist` for generating dist bundles.

## Stats

```
$ make list-dists
original 	 gzipped 	 file
--- 		 --- 		 ---
7.1K 		 2.0K 		 ./packages/frint-props/dist/frint-props.min.js
```