### PR TITLE
frint-props: `withHandlers` function

### DIFF
--- a/packages/frint-props/README.md
+++ b/packages/frint-props/README.md
@@ -16,6 +16,7 @@
   - [withState](#withstate)
   - [withStore](#withstore)
   - [withObservable](#withobservable)
+  - [withHandlers](#withhandlers)
   - [compose](#compose)
   - [map](#map)
   - [pipe](#pipe)
@@ -327,6 +328,49 @@ import { of } from 'rxjs/observable/of';
 const props$ = withObservable(
   () => of({ foo: 'foo value here' })
 )();
+```
+
+<!-- -->
+
+## withHandlers
+
+> withHandlers(handlers)
+
+This function can be only used via `compose`.
+
+### Arguments
+
+* `handlers` (`Object`): Functions keyed by prop name
+
+### Example
+
+```
+const props$ = compose(
+  withHandlers({
+    handleClick: props => () => console.log('Clicked!')
+  })
+)();
+```
+
+Other props are accessible too:
+
+```js
+const props$ = compose(
+  withState('counter', 'setCounter', 0),
+  withHandlers({
+    increment: props => () => props.setCounter(props.counter + 1)
+  })
+)();
+```
+
+Additional arguments can be accessed as follows:
+
+```js
+const props$ = compose(
+  withHandlers({
+    handleClick: (props, arg1, arg2) => () => console.log('Clicked!')
+  })
+)(arg1, arg2);
 ```
 
 <!-- -->

--- a/packages/frint-props/src/compose.js
+++ b/packages/frint-props/src/compose.js
@@ -26,7 +26,11 @@ export function compose(...items) {
       };
     }, {});
 
-    const result$ = merge(...observables)
+    const toMerge = observables.length === 0
+      ? [of({})]
+      : observables;
+
+    const result$ = merge(...toMerge)
       .pipe(...pipes);
 
     result$.defaultProps = defaultProps;

--- a/packages/frint-props/src/withHandlers.js
+++ b/packages/frint-props/src/withHandlers.js
@@ -1,0 +1,20 @@
+import { map } from 'rxjs/operators/map';
+
+export function withHandlers(handlers) {
+  return function (...args) {
+    return map((props) => {
+      const result = props;
+
+      Object
+        .keys(handlers)
+        .forEach((handlerName) => {
+          const handlerFunc = handlers[handlerName];
+          result[handlerName] = function (...handlerArgs) {
+            return handlerFunc(result, ...args)(...handlerArgs);
+          };
+        });
+
+      return result;
+    });
+  };
+}

--- a/packages/frint-props/src/withHandlers.spec.js
+++ b/packages/frint-props/src/withHandlers.spec.js
@@ -1,0 +1,60 @@
+/* global describe, test, expect */
+import { withState } from './withState';
+import { withHandlers } from './withHandlers';
+import { compose } from './compose';
+import { Tester } from './internal/Tester';
+
+describe('withHandlers', function () {
+  test('is a function', function () {
+    expect(typeof withHandlers).toBe('function');
+  });
+
+  test('has initial value', function () {
+    const t = new Tester(compose(
+      withHandlers({
+        foo: () => () => 'foo',
+      }),
+    )());
+    expect(typeof t.props.foo).toEqual('function');
+  });
+
+  test('can access other props', function () {
+    const t = new Tester(compose(
+      withState('counter', 'setCounter', 0),
+      withHandlers({
+        handleIncrement: props => () => props.setCounter(props.counter + 1),
+      }),
+    )());
+    expect(typeof t.props.handleIncrement).toEqual('function');
+    expect(typeof t.props.setCounter).toEqual('function');
+    expect(t.props.counter).toEqual(0);
+
+    t.props.handleIncrement();
+    expect(t.props.counter).toEqual(1);
+
+    t.props.handleIncrement();
+    t.props.handleIncrement();
+    expect(t.props.counter).toEqual(3);
+  });
+
+  test('can access arguments', function () {
+    const incrementSteps = 5;
+
+    const t = new Tester(compose(
+      withState('counter', 'setCounter', 0),
+      withHandlers({
+        handleIncrement: (props, steps) => () => props.setCounter(props.counter + steps),
+      }),
+    )(incrementSteps));
+    expect(typeof t.props.handleIncrement).toEqual('function');
+    expect(typeof t.props.setCounter).toEqual('function');
+    expect(t.props.counter).toEqual(0);
+
+    t.props.handleIncrement();
+    expect(t.props.counter).toEqual(5);
+
+    t.props.handleIncrement();
+    t.props.handleIncrement();
+    expect(t.props.counter).toEqual(15);
+  });
+});


### PR DESCRIPTION
Closes #24 

## What's done

* Added `withHandlers` function.
* Docs in diff (see README).

## What's NOT done

* No further props are generated upon triggering any individual handler
* I pushed for this idea in #24, but our API for functions cannot support it in any nice way that I can think of