### PR TITLE
Add support for null instead of mapState function to not subscribe to the store

### DIFF
--- a/packages/frint-props/README.md
+++ b/packages/frint-props/README.md
@@ -283,7 +283,7 @@ Works with `frint-store` or Redux store set in FrintJS App as a provider.
 
 ### Arguments
 
-1. `mapState` (`Function`): Maps state to props
+1. `mapState` (`Function` OR `null`): Maps state to props
 1. `mapDispatch` (`Object`): Action creators keyed by names
 1. `options` (`Object`) [optional]: Object with additional configuration
 1. `options.providerName` (`String`): Defaults to `store`
@@ -294,7 +294,32 @@ Works with `frint-store` or Redux store set in FrintJS App as a provider.
 ```js
 const app = new App(); // assuming it has a `store` provider
 
-const props$ = withState('counter', 'setCounter', 0)(app);
+const mapState = state => ({
+  foo: state.foo,
+  bar: state.bar
+});
+
+const mapDispatch = {
+  handleClick: () => ({
+    type: 'HANDLE_CLICK'
+  })
+};
+
+const props$ = withStore(mapState, mapDispatch)(app);
+```
+
+You can also pass `null` in place of `mapState` parameter if you don't want to subscribe to store updates.
+
+```js
+const app = new App(); // assuming it has a `store` provider
+
+const mapDispatch = {
+  handleClick: () => ({
+    type: 'HANDLE_CLICK'
+  })
+};
+
+const props$ = withStore(null, mapDispatch)(app);
 ```
 
 <!-- -->

--- a/packages/frint-props/src/withStore.js
+++ b/packages/frint-props/src/withStore.js
@@ -8,6 +8,10 @@ import { scan } from 'rxjs/operators/scan';
 function makeStateProps$(store, mapper) {
   const state$ = from(store);
 
+  if (mapper === null) {
+    return state$;
+  }
+
   return state$.pipe(
     map(state => mapper(state)),
   );

--- a/packages/frint-props/src/withStore.js
+++ b/packages/frint-props/src/withStore.js
@@ -6,11 +6,13 @@ import { switchMap } from 'rxjs/operators/switchMap';
 import { scan } from 'rxjs/operators/scan';
 
 function makeStateProps$(store, mapper) {
-  const state$ = from(store);
-
-  if (mapper === null) {
-    return state$;
+  // when no mapper is given, we can just stream a plain object once,
+  // which will be merged with dispatchable action creators later
+  if (!mapper) {
+    return of({});
   }
+
+  const state$ = from(store);
 
   return state$.pipe(
     map(state => mapper(state)),

--- a/packages/frint-props/src/withStore.spec.js
+++ b/packages/frint-props/src/withStore.spec.js
@@ -93,13 +93,16 @@ describe('withStore', function () {
 
   test('accept null as a mapper parameter', function () {
     const app = createAndInstantiateTestApp();
+    const mapDispatch = {
+      increment: incrementCounter,
+    };
 
     const t = new Tester(compose(
-      withStore(null, {
-        increment: incrementCounter,
-      }),
+      withStore(null, mapDispatch),
     )(app));
-    expect(typeof t.props.increment).toBe('function');
+
+    expect(t.props).toHaveProperty('increment');
+    expect(Object.keys(t.props)).toHaveLength(1);
   });
 
   test('can dispatch actions, and update value', function () {

--- a/packages/frint-props/src/withStore.spec.js
+++ b/packages/frint-props/src/withStore.spec.js
@@ -91,6 +91,17 @@ describe('withStore', function () {
     expect(t.props.counter).toBe(10);
   });
 
+  test('accept null as a mapper parameter', function () {
+    const app = createAndInstantiateTestApp();
+
+    const t = new Tester(compose(
+      withStore(null, {
+        increment: incrementCounter,
+      }),
+    )(app));
+    expect(typeof t.props.increment).toBe('function');
+  });
+
   test('can dispatch actions, and update value', function () {
     const app = createAndInstantiateTestApp();
 


### PR DESCRIPTION
**Problem**

If you only want to map dispatch functions on withStore, you need to pass a function that returns an empty object as mapState parameter. 

Eg:
```js
const mapState =() => ({});

const mapDispatch = {
  handleClick: () => ({
    type: 'HANDLE_CLICK'
  })
};

const props$ = withStore(mapState, mapDispatch)(app);
```

**Proposal**

Allow the user to pass `null` instead of mapState function if he only wants to map dispatch functions. 

Eg:
```js
const mapDispatch = {
  handleClick: () => ({
    type: 'HANDLE_CLICK'
  })
};

const props$ = withStore(null, mapDispatch)(app);
```

Close #28