### PR TITLE
Use a helper function to check if a value is an Observable instead of an external package

### DIFF
--- a/packages/frint-props/package.json
+++ b/packages/frint-props/package.json
@@ -24,7 +24,7 @@
     "frint"
   ],
   "dependencies": {
-    "is-observable": "^1.1.0"
+    "symbol-observable": "^1.2.0"
   },
   "devDependencies": {
     "cross-env": "^5.0.5"

--- a/packages/frint-props/src/compose.js
+++ b/packages/frint-props/src/compose.js
@@ -1,7 +1,7 @@
 import { of } from 'rxjs/observable/of';
 import { merge } from 'rxjs/observable/merge';
 import { scan } from 'rxjs/operators/scan';
-import isObservable from 'is-observable';
+import isObservable from './isObservable';
 
 export function compose(...items) {
   return function (...args) {

--- a/packages/frint-props/src/isObservable.js
+++ b/packages/frint-props/src/isObservable.js
@@ -1,0 +1,5 @@
+import symbolObservable from 'symbol-observable';
+
+const isObservable = value => Boolean(value && value[symbolObservable] && value === value[symbolObservable]());
+
+export default isObservable;

--- a/packages/frint-props/src/isObservable.js
+++ b/packages/frint-props/src/isObservable.js
@@ -1,3 +1,4 @@
+// https://github.com/sindresorhus/is-observable
 import symbolObservable from 'symbol-observable';
 
 const isObservable = value => Boolean(value && value[symbolObservable] && value === value[symbolObservable]());

--- a/packages/frint-props/src/isObservable.spec.js
+++ b/packages/frint-props/src/isObservable.spec.js
@@ -1,0 +1,20 @@
+/* global describe, test, expect */
+import { of } from 'rxjs/observable/of';
+import isObservable from './isObservable';
+
+describe('frint-props :: isObservable', function () {
+  test('is a function', function () {
+    expect(typeof isObservable).toBe('function');
+  });
+
+  test('it should return false for non Observables values', function () {
+    expect(isObservable(1)).toBeFalsy();
+    expect(isObservable([1])).toBeFalsy();
+    expect(isObservable({ foo: 'foo value here' })).toBeFalsy();
+  });
+
+  test('it should return true for Observables values', function () {
+    const observableValue = of({ foo: 'foo value here' });
+    expect(isObservable(observableValue)).toBeTruthy();
+  });
+});

--- a/packages/frint-props/src/withObservable.js
+++ b/packages/frint-props/src/withObservable.js
@@ -1,6 +1,6 @@
 import { of } from 'rxjs/observable/of';
 import { switchMap } from 'rxjs/operators/switchMap';
-import isObservable from 'is-observable';
+import isObservable from './isObservable';
 
 export function withObservable(source, ...mappers) {
   return function (...args) {


### PR DESCRIPTION
We are checking if a value is an Observable using an external package called `is-observable`. This package aims only server environments so they don't transpile the code for browsers which breaks our bundle on Internet Explorer 11. 

[I asked them to add support to browsers](https://github.com/sindresorhus/is-observable/issues/8) without success, so I decided to move the function to our codebase, since it is just one line of code.

Closes #30 